### PR TITLE
Use concret parent to make plexus-digest buildable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,8 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-components</artifactId>
-    <version>4.0-SNAPSHOT</version>
+    <version>4.0</version>
+    <relativePath/>
   </parent>
 
   <artifactId>plexus-digest</artifactId>


### PR DESCRIPTION
The current implementation points to plexus-components 4.0-SNAPSHOT, so it isn't buildable by independent developers like me.
This PR uses the already relased version 4.0 of plexus-components and sets the relativePath to nothing.
